### PR TITLE
closes #198 app threw errors coz it was trying to read token.name on coin transactions

### DIFF
--- a/src/components/Dashboard/widgets/Wallet/TxConfirmation.tsx
+++ b/src/components/Dashboard/widgets/Wallet/TxConfirmation.tsx
@@ -3,7 +3,12 @@ import { useSelector } from 'react-redux';
 
 import styled from '@emotion/styled';
 
-import { selectCurrentTxError, selectCurrentTxId, selectCurrentTxStatus } from 'store/selectors';
+import {
+  selectCurrenTxTokenTx,
+  selectCurrentTxError,
+  selectCurrentTxId,
+  selectCurrentTxStatus,
+} from 'store/selectors';
 
 import ErrorMessage from 'components/_General/ErrorMessage';
 import Spinner from 'components/_General/Spinner';
@@ -30,6 +35,7 @@ const TxConfirmation = ({
   const txStatus = useSelector(selectCurrentTxStatus);
   const txId = useSelector(selectCurrentTxId);
   const txError = useSelector(selectCurrentTxError);
+  const tokenTx = useSelector(selectCurrenTxTokenTx);
 
   return (
     <TxConfirmationRoot>
@@ -59,6 +65,7 @@ const TxConfirmation = ({
           recipient={recipient}
           currency={currency}
           timestamp={Date.now()}
+          tokenTx={tokenTx}
         />
       )}
     </TxConfirmationRoot>

--- a/src/components/Dashboard/widgets/Wallet/TxInformation.tsx
+++ b/src/components/Dashboard/widgets/Wallet/TxInformation.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import { DEFAULT_NULL_MODAL } from 'store/models/environment';
 import { dispatch } from 'store/rematch';
-import { selectCurrenTxTokenTx, selectCurrentTokenInfo } from 'store/selectors';
+import { selectCurrentTokenInfo } from 'store/selectors';
 import { formatDate, limitLength, stringifyAddresses } from 'util/helpers';
 import links from 'util/links';
 import { Colors, INFORMATION_N_A } from 'vars/defines';
@@ -42,6 +42,7 @@ type TxConfirmationProps = {
   txid: string;
   from: Array<string> | string;
   timestamp: number;
+  tokenTx?: boolean;
 };
 
 const closeModal = () => dispatch.environment.SET_MODAL(DEFAULT_NULL_MODAL);
@@ -53,8 +54,8 @@ const TxInformation = ({
   from,
   timestamp,
   recipient,
+  tokenTx,
 }: TxConfirmationProps): ReactElement => {
-  const tokenTx = useSelector(selectCurrenTxTokenTx);
   const currentToken = useSelector(selectCurrentTokenInfo);
   // const usdValueTemp = formatFiat(Number(amount) * Number(usdValue));
   return (


### PR DESCRIPTION
Problem: App throws an error trying to read token detail, when viewing coin transaction details. 

Solution: After sending token transactions tokenTx stayed true and was read as true even when you opened a coin transactions. tokenTx parameter moved a level higher, it was confusing token and coin transactions.
