### PR TITLE
Turn off ASAR usage in electron-builder (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "*.{html,md,yml}": ["prettier --ignore-path .eslintignore --single-quote --write"]
   },
   "build": {
-    "asar": true,
+    "asar": false,
     "productName": "TokelPlatform",
     "appId": "tokel",
     "directories": {


### PR DESCRIPTION
Originally when we turned off ASAR packaging in `electron-builder` it
was because we found it mildly annoying when we were debugging the build
process early on, as we had to unpack the contents every time to see
what was going wrong with the build.

However `electron-builder` says this is "strongly not recommended", and
so I turned it back on as a last minute addition to the new GH Actions
build pipeline.

Unfortunately, turning on ASAR usage now actually breaks the build, due
to changes in this commit: 7a9c8724bd3272d45254fab32a5992e066233f64.

So for now I have re-disabled ASAR. Future work should probably
investigate this to see if we can get it working again, but at the
moment it is not a priority, as the main benefits of ASAR are:
1. Slightly faster due to no `require`
2. Smaller memory footprint (it's read from memory compressed like TAR)
3. Slight obfuscation of source code

1 and 2 are probably useful long-term, but 3 is a non-issue since Tokel
is an open-source project anyway.