### PR TITLE
Fixed logic on processing the value of the requests

### DIFF
--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -75,9 +75,9 @@ export const toBitcoinAmount = (amountInSatoshi: string): string => {
   let value;
 
   if (bnAmountInSatoshi.lt(bnSatoshis)) {
-    value = parseInt(amountInSatoshi, 10) / SATOSHIS;
-  } else {
     value = bnAmountInSatoshi.div(bnSatoshis).toNumber(); // Okay to do toNumber as we're dealing with TKL and not satoshis
+  } else {
+    value = parseInt(amountInSatoshi, 10) / SATOSHIS;
   }
 
   return Number(value.toFixed(Config.DECIMAL)).toString();

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -2,6 +2,7 @@ import BN from 'bn.js';
 import format from 'date-fns/format';
 import fromUnixTime from 'date-fns/fromUnixTime';
 import getUnixTime from 'date-fns/getUnixTime';
+import { toBitcoin } from 'satoshi-bitcoin';
 
 import BigNumObject from 'util/types/BigNum';
 import { Config, EXTRACT_IPFS_HASH_REGEX, SATOSHIS, WindowSize } from 'vars/defines';
@@ -73,22 +74,19 @@ export const toBitcoinAmount = (amountInSatoshi: string): string => {
   const bnAmountInSatoshi = new BN(amountInSatoshi);
   const bnSatoshis = new BN(SATOSHIS);
   let value;
+  let decimals;
 
   if (bnAmountInSatoshi.lt(bnSatoshis)) {
     value = parseInt(amountInSatoshi, 10) / SATOSHIS;
-    value = Number(value.toFixed(Config.DECIMAL)).toString();
+    value = Number(value.toFixed(Config.DECIMAL));
   } else {
-    value = bnAmountInSatoshi.div(bnSatoshis).toNumber(); // Okay to do toNumber as we're dealing with TKL and not satoshis
+    value = bnAmountInSatoshi.div(bnSatoshis).toNumber();
+    decimals = toBitcoin(bnAmountInSatoshi.mod(bnSatoshis).toNumber());
 
-    value = parseFloat(
-      `${value.toString()}.${bnAmountInSatoshi
-        .toNumber()
-        .toString()
-        .substring(value.toString().length)}`
-    );
+    value = Number(value + decimals);
   }
 
-  return value;
+  return value.toString();
 };
 
 export const getUsdValue = (amountInSatoshi: string, tokelPriceUSD: number) =>

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -75,12 +75,20 @@ export const toBitcoinAmount = (amountInSatoshi: string): string => {
   let value;
 
   if (bnAmountInSatoshi.lt(bnSatoshis)) {
-    value = bnAmountInSatoshi.div(bnSatoshis).toNumber(); // Okay to do toNumber as we're dealing with TKL and not satoshis
-  } else {
     value = parseInt(amountInSatoshi, 10) / SATOSHIS;
+    value = Number(value.toFixed(Config.DECIMAL)).toString();
+  } else {
+    value = bnAmountInSatoshi.div(bnSatoshis).toNumber(); // Okay to do toNumber as we're dealing with TKL and not satoshis
+
+    value = parseFloat(
+      `${value.toString()}.${bnAmountInSatoshi
+        .toNumber()
+        .toString()
+        .substring(value.toString().length)}`
+    );
   }
 
-  return Number(value.toFixed(Config.DECIMAL)).toString();
+  return value;
 };
 
 export const getUsdValue = (amountInSatoshi: string, tokelPriceUSD: number) =>


### PR DESCRIPTION
Hey there :D

If you have sent some TKLs with the dApp you probably noticed that the values are not properly displayed in the description and the activity list. Well, I might have the solution for that particular issue...

In the next two screenshots, you can see the value of a transaction being displayed as 1TKL, which is not correct:

<img width="484" alt="image" src="https://user-images.githubusercontent.com/14826006/165190768-36550b0b-fcea-4766-9474-fd1c7793417b.png">
<img width="439" alt="image" src="https://user-images.githubusercontent.com/14826006/165190778-46f11b20-dc9b-4864-bae9-c436187cbdc4.png">

Now, in the next two screenshots, you can see the value fixed, displaying the actual amount of that transaction:

<img width="491" alt="image" src="https://user-images.githubusercontent.com/14826006/165190863-eea2d7e3-5d1a-4b56-99be-4d66b220eee3.png">
<img width="437" alt="image" src="https://user-images.githubusercontent.com/14826006/165190871-a3b6b830-e21e-4a93-b79d-8a93353f4984.png">

Note: Older transactions should be displaying the appropriated values again, after implementing this solution