### PR TITLE
Removed limit on IPFS_HASH_REGEX

### DIFF
--- a/src/vars/defines.ts
+++ b/src/vars/defines.ts
@@ -34,7 +34,7 @@ export enum NetworkType {
 export const DEFAULT_NETWORK = IS_DEV ? NetworkType.TKLTEST : NetworkType.TOKEL;
 
 export const EXTRACT_IPFS_HASH_REGEX =
-  /^(?:https:\/\/ipfs.io\/ipfs\/|ipfs:\/\/|dweb:\/\/)([a-zA-Z0-9]{46})/;
+  /^(?:https:\/\/ipfs.io\/ipfs\/|ipfs:\/\/|dweb:\/\/)([a-zA-Z0-9]*$)/;
 
 export const TokenFilter = {
   ALL: 'ALL',


### PR DESCRIPTION
Hi there! 👋

Pretty excited for this one...

We've been having issues with NFT loading and wrong hashes being parsed, etc... Well, this is the solution to all of these problems! 🙌

Initially, we had validation for the hash sizes, limiting the hashes to 46 characters. Once removed, the hashes now load properly and display their full length.

closes #280 
closes #291 

Two issues with one PR! I wish this happens more often in the future 😆