### PR TITLE
Feature/whitelist images by token

### DIFF
--- a/src/components/_General/TokenMediaDisplay.tsx
+++ b/src/components/_General/TokenMediaDisplay.tsx
@@ -48,7 +48,6 @@ const DisclaimerText = styled.div`
   text-align: justify;
   text-align-last: center;
   font-size: 0.9rem;
-  margin-top: 25px;
 `;
 
 interface TokenMediaDisplayProps {
@@ -61,6 +60,7 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
   const [iframeHeight, setIframeHeight] = useState<number | 'unset'>('unset');
   const [mediaUrl, setMediaUrl] = useState(null);
   const [mediaShouldLoad, setMediaShouldLoad] = useState(false);
+  const [readMore, setReadMore] = useState(false);
 
   const ipfsId = useMemo(() => extractIPFSHash(url), [url]);
   const tokenAddress = ipfsId || url;
@@ -71,6 +71,7 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
     setMediaUrl(null);
     setIframeLoaded(false);
     setMediaShouldLoad(false);
+    setReadMore(false);
     iframeRef.current?.contentWindow.postMessage({ mediaUrl: '', width: 0 });
   }, [url]);
 
@@ -182,31 +183,51 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
       {!mediaShouldLoad && (
         <div style={{ textAlign: 'center' }}>
           <img alt="warning" src={warning} />
+          <p>Disclaimer</p>
 
-          <DisclaimerText>
-            The Tokel team does not own, endorse, host or content moderate anything that is shown in
-            the dApp. By it&apos;s nature, the dApp merely reads the media URL&apos;s that are
-            linked within the meta data of tokens that are created on the Tokel public blockchain.
-            Content moderation issues should be addressed with the token creator, owner, or through
-            the web host that stores the media itself.
-          </DisclaimerText>
-          <DisclaimerText>
-            By accepting this disclaimer, you are accepting that you have personally verified the
-            source of the image and are happy for it to be displayed, knowing that there are no
-            content moderators and you&apos;re taking all responsibility for viewing the media and
-            any risks associated with that. You are accepting that anybody that participates in
-            creating and/or shipping this open source software holds no liability for what is shown,
-            and that the decision to proceed is completely voluntary and at your own risk.
-          </DisclaimerText>
+          {!readMore && (
+            <>
+              <DisclaimerText>
+                The Tokel team does not own, endorse, host or content moderate anything that is
+                shown in the dApp. By it&apos;s nature, the dApp merely reads...
+              </DisclaimerText>
+              <br />
+              <ButtonSmall type="button" theme="purpler" onClick={() => setReadMore(true)}>
+                Read More
+              </ButtonSmall>
+            </>
+          )}
 
-          <ButtonWrapper>
-            <ButtonSmall type="button" theme="success" onClick={() => setMediaShouldLoad(true)}>
-              View once
-            </ButtonSmall>
-            <ButtonSmall type="button" theme="purple" onClick={() => addTokenToWhiteList()}>
-              View and never ask again
-            </ButtonSmall>
-          </ButtonWrapper>
+          {readMore && (
+            <>
+              <DisclaimerText>
+                The Tokel team does not own, endorse, host or content moderate anything that is
+                shown in the dApp. By it&apos;s nature, the dApp merely reads the media URL&apos;s
+                that are linked within the meta data of tokens that are created on the Tokel public
+                blockchain. Content moderation issues should be addressed with the token creator,
+                owner, or through the web host that stores the media itself.
+              </DisclaimerText>
+              <br />
+              <DisclaimerText>
+                By accepting this disclaimer, you are accepting that you have personally verified
+                the source of the image and are happy for it to be displayed, knowing that there are
+                no content moderators and you&apos;re taking all responsibility for viewing the
+                media and any risks associated with that. You are accepting that anybody that
+                participates in creating and/or shipping this open source software holds no
+                liability for what is shown, and that the decision to proceed is completely
+                voluntary and at your own risk.
+              </DisclaimerText>
+
+              <ButtonWrapper>
+                <ButtonSmall type="button" theme="success" onClick={() => setMediaShouldLoad(true)}>
+                  View once
+                </ButtonSmall>
+                <ButtonSmall type="button" theme="purple" onClick={() => addTokenToWhiteList()}>
+                  View and never ask again
+                </ButtonSmall>
+              </ButtonWrapper>
+            </>
+          )}
         </div>
       )}
     </>

--- a/src/components/_General/TokenMediaDisplay.tsx
+++ b/src/components/_General/TokenMediaDisplay.tsx
@@ -5,7 +5,12 @@ import { ipcRenderer } from 'electron';
 
 import { Responsive, extractIPFSHash } from 'util/helpers';
 import { V } from 'util/theming';
-import { DEFAULT_IPFS_FALLBACK_GATEWAY, IPFS_IPC_ID, IpfsAction } from 'vars/defines';
+import {
+  DEFAULT_IPFS_FALLBACK_GATEWAY,
+  IPFS_IPC_ID,
+  IpfsAction,
+  TOKEN_WHITE_LIST_LOCATION,
+} from 'vars/defines';
 
 const MediaContent = styled.div`
   overflow-y: auto;
@@ -40,29 +45,38 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
   const [mediaUrl, setMediaUrl] = useState(null);
 
   const ipfsId = useMemo(() => extractIPFSHash(url), [url]);
+  const tokenAddress = ipfsId || url;
+  const tokenInWhiteList =
+    JSON.parse(localStorage.getItem(`${TOKEN_WHITE_LIST_LOCATION}/${tokenAddress}`)) || false;
+
+  const [mediaShouldLoad, setMediaShouldLoad] = useState(tokenInWhiteList);
 
   useEffect(() => {
     setIframeHeight('unset');
     setMediaUrl(null);
+    setIframeLoaded(false);
+    setMediaShouldLoad(tokenInWhiteList);
     iframeRef.current?.contentWindow.postMessage({ mediaUrl: '', width: 0 });
-  }, [url]);
+  }, [url, tokenInWhiteList]);
 
   // Request IPFS file if it's an IPFS link. Set link meanwhile anyway
   useEffect(() => {
-    if (ipfsId) {
-      ipcRenderer.send(IPFS_IPC_ID, {
-        type: IpfsAction.GET,
-        payload: {
-          ipfsId,
-        },
-      });
+    if (iframeLoaded) {
+      if (ipfsId) {
+        ipcRenderer.send(IPFS_IPC_ID, {
+          type: IpfsAction.GET,
+          payload: {
+            ipfsId,
+          },
+        });
 
-      // Set fallback in case IPFS data never streams to our node
-      setMediaUrl(`${DEFAULT_IPFS_FALLBACK_GATEWAY}/${ipfsId}`);
-    } else {
-      setMediaUrl(url);
+        // Set fallback in case IPFS data never streams to our node
+        setMediaUrl(`${DEFAULT_IPFS_FALLBACK_GATEWAY}/${ipfsId}`);
+      } else {
+        setMediaUrl(url);
+      }
     }
-  }, [url, ipfsId]);
+  }, [url, ipfsId, iframeLoaded]);
 
   // Listen for IPFS files
   useEffect(() => {
@@ -107,19 +121,36 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
     };
   }, [iframeRef, iframeLoaded]);
 
-  if (!mediaUrl) return null;
+  function addTokenToWhiteList() {
+    localStorage.setItem(`${TOKEN_WHITE_LIST_LOCATION}/${tokenAddress}`, 'true');
+    setMediaShouldLoad(true);
+  }
 
   return (
-    <MediaContent>
-      <ImageFrame>
-        <TokenMediaIframe
-          height={iframeHeight}
-          ref={iframeRef}
-          src={`file://${__dirname}/externalMedia.html`}
-          onLoad={() => setIframeLoaded(true)}
-        />
-      </ImageFrame>
-    </MediaContent>
+    <>
+      {mediaShouldLoad && (
+        <MediaContent>
+          <ImageFrame>
+            <TokenMediaIframe
+              height={iframeHeight}
+              ref={iframeRef}
+              src={`file://${__dirname}/externalMedia.html`}
+              onLoad={() => setIframeLoaded(true)}
+            />
+          </ImageFrame>
+        </MediaContent>
+      )}
+      {!mediaShouldLoad && (
+        <>
+          <button type="button" onClick={() => setMediaShouldLoad(true)}>
+            Load this time
+          </button>
+          <button type="button" onClick={() => addTokenToWhiteList()}>
+            Always load this token
+          </button>
+        </>
+      )}
+    </>
   );
 };
 

--- a/src/components/_General/TokenMediaDisplay.tsx
+++ b/src/components/_General/TokenMediaDisplay.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { ipcRenderer } from 'electron';
 
+import warning from 'assets/warningIcon.svg';
 import { Responsive, extractIPFSHash } from 'util/helpers';
 import { V } from 'util/theming';
 import {
@@ -37,15 +38,17 @@ const TokenMediaIframe = styled.iframe`
 `;
 
 const ButtonWrapper = styled.div`
+  width: 100%;
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
   margin-top: 25px;
 `;
 
-const DisclaimerText = styled.p`
+const DisclaimerText = styled.div`
   text-align: justify;
   text-align-last: center;
   font-size: 0.9rem;
+  margin-top: 25px;
 `;
 
 interface TokenMediaDisplayProps {
@@ -142,25 +145,44 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
     setMediaShouldLoad(true);
   }
 
+  function removeTokenFromWhiteList() {
+    localStorage.removeItem(`${TOKEN_WHITE_LIST_LOCATION}/${tokenAddress}`);
+    setMediaShouldLoad(false);
+    setIframeLoaded(false);
+  }
+
   return (
     <>
       {mediaShouldLoad && (
-        <MediaContent>
-          <ImageFrame>
-            <TokenMediaIframe
-              height={iframeHeight}
-              ref={iframeRef}
-              src={`file://${__dirname}/externalMedia.html`}
-              onLoad={() => {
-                setIframeLoaded(true);
-                setMediaShouldLoad(true);
-              }}
-            />
-          </ImageFrame>
-        </MediaContent>
+        <>
+          <MediaContent>
+            <ImageFrame>
+              <TokenMediaIframe
+                height={iframeHeight}
+                ref={iframeRef}
+                src={`file://${__dirname}/externalMedia.html`}
+                onLoad={() => {
+                  setIframeLoaded(true);
+                  setMediaShouldLoad(true);
+                }}
+              />
+            </ImageFrame>
+          </MediaContent>
+          <ButtonWrapper>
+            <ButtonSmall
+              type="button"
+              theme="transparent"
+              onClick={() => removeTokenFromWhiteList()}
+            >
+              Hide Image
+            </ButtonSmall>
+          </ButtonWrapper>
+        </>
       )}
       {!mediaShouldLoad && (
-        <>
+        <div style={{ textAlign: 'center' }}>
+          <img alt="warning" src={warning} />
+
           <DisclaimerText>
             The Tokel team does not own, endorse, host or content moderate anything that is shown in
             the dApp. By it&apos;s nature, the dApp merely reads the media URL&apos;s that are
@@ -176,6 +198,7 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
             creating and/or shipping this open source software holds no liability for what is shown,
             and that the decision to proceed is completely voluntary and at your own risk.
           </DisclaimerText>
+
           <ButtonWrapper>
             <ButtonSmall type="button" theme="success" onClick={() => setMediaShouldLoad(true)}>
               View once
@@ -184,7 +207,7 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
               View and never ask again
             </ButtonSmall>
           </ButtonWrapper>
-        </>
+        </div>
       )}
     </>
   );

--- a/src/components/_General/TokenMediaDisplay.tsx
+++ b/src/components/_General/TokenMediaDisplay.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { ipcRenderer } from 'electron';
 
-import warning from 'assets/warningIcon.svg';
 import { Responsive, extractIPFSHash } from 'util/helpers';
 import { V } from 'util/theming';
 import {
@@ -14,6 +13,7 @@ import {
 } from 'vars/defines';
 
 import { ButtonSmall } from 'components/_General/buttons';
+import FriendlyWarning from 'components/_General/WarningFriendly';
 
 const MediaContent = styled.div`
   overflow-y: auto;
@@ -182,8 +182,9 @@ const TokenMediaDisplay: React.FC<TokenMediaDisplayProps> = ({ url }) => {
       )}
       {!mediaShouldLoad && (
         <div style={{ textAlign: 'center' }}>
-          <img alt="warning" src={warning} />
-          <p>Disclaimer</p>
+          <FriendlyWarning message="Image Preview Disclaimer" />
+
+          <br />
 
           {!readMore && (
             <>

--- a/src/vars/defines.ts
+++ b/src/vars/defines.ts
@@ -26,6 +26,8 @@ export const IS_DEV = process.env.NODE_ENV === 'development' || process.env.NODE
 export const IS_PROD = process.env.NODE_ENV === 'production';
 export const SATOSHIS = 100000000;
 
+export const TOKEN_WHITE_LIST_LOCATION = 'token_white_list';
+
 export enum NetworkType {
   TOKEL = 'TOKEL',
   TKLTEST = 'TKLTEST2',


### PR DESCRIPTION
Hi everyone, back in here for another improvement! 🚀

I've been working on issue #200 for a while now, and it's finally here. I have added the disclaimer text along with 2 buttons for every token view. So you have the option to see it once, or to trust that token and never be prompted with the disclaimer for that specific token again.

I also thought it was a good idea to add a button to hide the token, so if you accidentally clicked to trust the token but you didn't want to, you can undo it.

All these behaviors can be seen in the video below:

https://user-images.githubusercontent.com/14826006/178577769-259586fc-1b3d-41d3-966e-00ab0f8d4921.mov

<img width="424" alt="image" src="https://user-images.githubusercontent.com/14826006/178577964-91bae8f8-783d-4a42-900f-04f6bbc6f33a.png">
<img width="424" alt="image" src="https://user-images.githubusercontent.com/14826006/178577997-609b0a42-df63-4355-b617-738c44a8471b.png">
<img width="359" alt="image" src="https://user-images.githubusercontent.com/14826006/178578028-bdee8176-43e6-4d7f-ad7a-9a31a2d6de24.png">

closes #200 